### PR TITLE
remove hashlib from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ flask_api
 passlib
 paramiko
 requests
-hashlib
 git+https://github.com/gorakhargosh/watchdog.git


### PR DESCRIPTION
this is built in to python and makes pip install sad